### PR TITLE
vm.dices のフォーマット変更

### DIFF
--- a/fluorite5.pegjs
+++ b/fluorite5.pegjs
@@ -96,7 +96,7 @@
             t += value;
             values.push(value);
           }
-          vm.dices.push([faces, values]);
+          vm.dices.push({ faces: faces, results: values });
           return t;
         }
 
@@ -1476,7 +1476,7 @@
               t += value;
               values.push(value);
             }
-            vm.dices.push([faces, values]);
+            vm.dices.push({ faces: faces, results: values });
             return t;
           }
           vm.scope.setOrDefine("function_d", vm.packVector([


### PR DESCRIPTION
配列だと可読性が低いので以下の様なオブジェクトにしたい。

``` js
vm.dices.push({ faces: faces, results: values })
```

Nekochatは https://github.com/ukatama/nekochat/commit/19af0d44c3e7d0b824a310e98fb84f0827d0cf58 で変更済み。
